### PR TITLE
Make sure to return all alignments overlapping with the specified region.

### DIFF
--- a/src/tinyscibio/bam.py
+++ b/src/tinyscibio/bam.py
@@ -754,10 +754,6 @@ def walk_bam(
     with pysam.AlignmentFile(fspath, "rb") as bamf:
         idx = 0
         for aln in bamf.fetch(contig=rname, start=start, stop=end):
-            # Make sure to only grab alignments at and after given start
-            # position and before given end position
-            if aln.reference_start < start:
-                continue
             if aln.query_name is None:
                 continue
             # Skip records whose read group is not defined in read_groups

--- a/tests/test_walk_bam.py
+++ b/tests/test_walk_bam.py
@@ -59,7 +59,7 @@ class MockAlignmentFile:
     ):
         # FIXME: this is better defined in the class for each available contig
         # FIXME: becuase bam_start and bam_end defines what inside the BAM
-        bam_start = 90  # the very first mapped position on rname in the BAM
+        bam_start = 100  # the very first mapped position on rname in the BAM
         # the very last mapped position on rname in the BAM
         # here simply set to length of the given contig
         bam_end = int(self.seqmap()[contig])
@@ -188,7 +188,7 @@ def init_mock_alignment_file(monkeypatch):
 
 def test_walk_bam(monkeypatch):
     init_mock_alignment_file(monkeypatch)
-    region = "chr1:100-104"
+    region = "chr1:90-104"
     res_df = walk_bam(
         "test.bam",
         region,
@@ -328,16 +328,16 @@ def test_walk_bam_filtered_by_exclude(monkeypatch):
     ).all()
 
 
-def test_walk_bam_grabs_at_and_after_start_position(monkeypatch):
-    init_mock_alignment_file(monkeypatch)
-    # one-based, the first fetched position should be 101
-    region = "chr1:102-103"
-    res_df = walk_bam(
-        "test.bam",
-        region,
-        exclude=3840,
-        return_qname=True,
-    )
-
-    assert res_df.shape[0] == 1
-    assert res_df[0, "rstarts"] == 101
+# def test_walk_bam_grabs_at_and_after_start_position(monkeypatch):
+#     init_mock_alignment_file(monkeypatch)
+#     # one-based, the first fetched position should be 101
+#     region = "chr1:102-103"
+#     res_df = walk_bam(
+#         "test.bam",
+#         region,
+#         exclude=3840,
+#         return_qname=True,
+#     )
+#
+#     assert res_df.shape[0] == 1
+#     assert res_df[0, "rstarts"] == 101


### PR DESCRIPTION
- A small patch to fix the error where alignments who overlap with specified region on their 3’ end are skipped.